### PR TITLE
Fixed Eigen include dirs variable in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ target_include_directories(${LIBRARY_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOU
                                            ${iDynTree_INCLUDE_DIRS}
                                            ${skinDynLib_INCLUDE_DIRS}
                                            ${ctrlLib_INCLUDE_DIRS}
-                                           ${EIGEN3_INCLUDE_DIRS})
+                                           ${EIGEN3_INCLUDE_DIR})
 
 target_link_libraries(${LIBRARY_NAME} ${YARP_LIBRARIES}
                                       ${iDynTree_LIBRARIES}


### PR DESCRIPTION
This is a strange behavior and I didn't spent much time on it. I tried to build `idyntree` before the the `codyco-superbuild`. With this setting, `codyco-commons` from the superbuild complains because `Eigen/Core` is not found. This commit fixes the link with `Eigen`.

I have no idea why before this was working. Probably `idyntree` was setting some variables read by `codyco-commons`, even though the project inside the superbuild should be independent by each other.